### PR TITLE
Add status error handling

### DIFF
--- a/Sources/App/View/ContentView.swift
+++ b/Sources/App/View/ContentView.swift
@@ -33,6 +33,16 @@ struct ContentView: View {
         .onAppear {
             viewModel.requestPermissions()
         }
+        .alert("Error", isPresented: Binding(
+            get: { viewModel.errorMessage != nil },
+            set: { _ in viewModel.errorMessage = nil }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            if let message = viewModel.errorMessage {
+                Text(message)
+            }
+        }
         .alert("Permissions Denied", isPresented: .constant(!viewModel.permissionsGranted)) {
             Button("OK", role: .cancel) {}
         } message: {

--- a/Sources/App/ViewModel/AppViewModel.swift
+++ b/Sources/App/ViewModel/AppViewModel.swift
@@ -7,6 +7,7 @@ class AppViewModel: ObservableObject {
     @Published var lastScreenshotURL: URL?
     @Published var permissionsGranted = false
     @Published var recordAudio = false
+    @Published var errorMessage: String?
 
     let screenManager = ScreenCaptureManager()
 
@@ -49,6 +50,7 @@ extension AppViewModel: ScreenCaptureManagerDelegate {
 
     func screenCaptureManager(_ manager: ScreenCaptureManager, didFail error: Error) {
         isRecording = false
+        errorMessage = error.localizedDescription
         print("ScreenCapture error: \(error)")
     }
 }

--- a/TASKS.md
+++ b/TASKS.md
@@ -29,7 +29,7 @@ This file breaks down the steps required to implement the application described 
 
 ## 5. System Integration and UX
 - [x] Request and handle Screen Recording and microphone permissions.
-- [ ] Provide status indicators and error messages.
+- [x] Provide status indicators and error messages.
 - [ ] Manage resources to avoid leaks (stop streams, release writers).
 
 ## 6. Future Enhancements (Post-MVP)


### PR DESCRIPTION
## Summary
- show error messages in `AppViewModel` and expose to UI
- alert user when an error occurs
- mark task as complete for status indicators

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685d66d2df6c8330b5756d803a64d425