### PR TITLE
Add interactive screenshot options

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -25,13 +25,16 @@ Successfully transformed Puch from a traditional window-based app to a modern **
 - **Proper Management**: Separate WindowGroups with IDs
 
 ### 4. **Enhanced UX**
+ - **Flexible Screenshots**: Capture full screen, selected window, or custom area
 
 #### Menu Bar Dropdown
 ```
 ┌─────────────────────┐
 │ 📹 Puch        ● Recording │
 ├─────────────────────┤
-│ 📷 Take Screenshot  ⌘⇧3 │
+│ 📷 Full Screenshot   ⌘⇧3 │
+│ 🪟 Window Screenshot │
+│ ➕ Area Screenshot   │
 │ ⏹️  Stop Recording   ⌘⇧5 │
 │ 🎤 Record Audio     ⚪️ │
 ├─────────────────────┤
@@ -124,7 +127,6 @@ The app now provides:
 
 Ready for:
 - **Custom Hotkeys**: Settings UI already prepared
-- **More Capture Types**: Area selection, window capture
 - **Cloud Integration**: Upload to services
 - **Automation**: Scheduled captures, workflows
-- **Advanced History**: Tags, search, organization 
+- **Advanced History**: Tags, search, organization

--- a/README.md
+++ b/README.md
@@ -10,11 +10,14 @@ A powerful, lightweight **menu bar** screen capture application for macOS with g
 - **Quick Access**: One-click access to all capture functions
 - **Non-intrusive**: Stays out of your way until needed
 
-### ⌨️ **Global Hotkeys** 
+### ⌨️ **Global Hotkeys**
 - **Screenshot**: `⌘⇧3` - Instant full screen capture
 - **Recording**: `⌘⇧5` - Toggle screen recording on/off
 - **System-wide**: Works from any app, no need to switch windows
 - **Native Feel**: follows macOS screenshot conventions
+
+### 🖼️ **Flexible Screenshots**
+- Capture the entire screen, a specific window, or a custom area
 
 ### 📹 **Advanced Recording**
 - **High-quality**: Full resolution screen recording

--- a/Sources/App/View/MenuBarView.swift
+++ b/Sources/App/View/MenuBarView.swift
@@ -34,11 +34,29 @@ struct MenuBarView: View {
             Group {
                 MenuButton(
                     icon: "camera.fill",
-                    title: "Take Screenshot",
+                    title: "Full Screenshot",
                     shortcut: "⌘⇧3",
                     color: .green
                 ) {
                     viewModel.takeScreenshot()
+                }
+                .disabled(!viewModel.permissionsGranted)
+
+                MenuButton(
+                    icon: "macwindow.on.rectangle",
+                    title: "Window Screenshot",
+                    color: .green
+                ) {
+                    viewModel.takeScreenshot(mode: .window)
+                }
+                .disabled(!viewModel.permissionsGranted)
+
+                MenuButton(
+                    icon: "crop",
+                    title: "Area Screenshot",
+                    color: .green
+                ) {
+                    viewModel.takeScreenshot(mode: .area)
                 }
                 .disabled(!viewModel.permissionsGranted)
                 

--- a/Sources/App/ViewModel/AppViewModel.swift
+++ b/Sources/App/ViewModel/AppViewModel.swift
@@ -60,8 +60,8 @@ class AppViewModel: ObservableObject {
         screenManager.stopRecording()
     }
 
-    func takeScreenshot() {
-        screenManager.takeScreenshot()
+    func takeScreenshot(mode: ScreenshotMode = .fullScreen) {
+        screenManager.takeScreenshot(mode: mode)
     }
 
     func requestPermissions() {


### PR DESCRIPTION
## Summary
- allow capturing a specific window or area in `ScreenCaptureManager`
- expose new screenshot mode in `AppViewModel`
- add window/area screenshot buttons in the menu bar
- document flexible screenshot options in README and implementation summary

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685d916263ec8330bb8ee3cb581406e8