### PR TITLE
Add customizable window screenshot backgrounds

### DIFF
--- a/Sources/App/Model/PersistenceManager.swift
+++ b/Sources/App/Model/PersistenceManager.swift
@@ -8,8 +8,23 @@ final class PersistenceManager: Sendable {
     private let defaults = UserDefaults.standard
 
     struct Settings: Codable, Sendable {
+        enum WindowScreenshotBackground: String, Codable, CaseIterable, Sendable {
+            case desktop
+            case white
+            case gradient
+        }
+
         var outputDirectory: URL
         var frameRate: Int
+        var windowScreenshotBackground: WindowScreenshotBackground
+
+        static var `default`: Settings {
+            Settings(
+                outputDirectory: FileManager.default.urls(for: .desktopDirectory, in: .userDomainMask).first ?? FileManager.default.temporaryDirectory,
+                frameRate: 60,
+                windowScreenshotBackground: .desktop
+            )
+        }
     }
 
     func saveSettings(_ settings: Settings) {

--- a/Sources/App/View/SettingsView.swift
+++ b/Sources/App/View/SettingsView.swift
@@ -56,6 +56,15 @@ struct GeneralSettingsView: View {
                 Toggle("Record Audio by Default", isOn: $viewModel.recordAudio)
                     .help("Enable audio recording for screen recordings")
             }
+
+            Section("Window Screenshot") {
+                Picker("Background", selection: $viewModel.windowScreenshotBackground) {
+                    Text("Desktop").tag(PersistenceManager.Settings.WindowScreenshotBackground.desktop)
+                    Text("White").tag(PersistenceManager.Settings.WindowScreenshotBackground.white)
+                    Text("Gradient").tag(PersistenceManager.Settings.WindowScreenshotBackground.gradient)
+                }
+                .pickerStyle(.segmented)
+            }
             
             Section("File Management") {
                 HStack {

--- a/Sources/App/ViewModel/AppViewModel.swift
+++ b/Sources/App/ViewModel/AppViewModel.swift
@@ -8,14 +8,26 @@ class AppViewModel: ObservableObject {
     @Published var lastScreenshotURL: URL?
     @Published var permissionsGranted = false
     @Published var recordAudio = false
+    @Published var windowScreenshotBackground: PersistenceManager.Settings.WindowScreenshotBackground = .desktop {
+        didSet {
+            persistenceSettings.windowScreenshotBackground = windowScreenshotBackground
+            PersistenceManager.shared.saveSettings(persistenceSettings)
+            screenManager.windowBackground = windowScreenshotBackground
+        }
+    }
     @Published var errorMessage: String?
 
     let screenManager: ScreenCaptureManager
     private var permissionMonitorTimer: Timer?
+    private var persistenceSettings: PersistenceManager.Settings
 
     init() {
         screenManager = ScreenCaptureManager()
         screenManager.delegate = self
+        let loaded = PersistenceManager.shared.loadSettings() ?? .default
+        persistenceSettings = loaded
+        windowScreenshotBackground = loaded.windowScreenshotBackground
+        screenManager.windowBackground = windowScreenshotBackground
         setupNotificationObservers()
         checkPermissionsStatus()
         startPermissionMonitoring()


### PR DESCRIPTION
## Summary
- store window screenshot background in `PersistenceManager` settings
- expose background option in `AppViewModel` and save it
- present picker in settings UI
- render background when capturing window screenshots

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_685d93f1b8f0833098a410e35e202214